### PR TITLE
Add PRM metadata to www-authenticate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,7 @@ const dearerAuthMiddlewareOptions: BearerAuthMiddlewareOptions = {
   verifier: {
     verifyAccessToken: authProvider.verifyAccessToken.bind(authProvider),
   },
-  resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(BASE_URI),
+  resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(new URL(BASE_URI)),
 }
 
 app.use(mcpAuthRouter(options));


### PR DESCRIPTION

```
❯ curl -v http://localhost:3232/mcp
* Host localhost:3232 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:3232...
* Connected to localhost (::1) port 3232
> GET /mcp HTTP/1.1
> Host: localhost:3232
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 401 Unauthorized
< X-Powered-By: Express
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< Strict-Transport-Security: max-age=31536000; includeSubDomains
< Content-Security-Policy: default-src 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; base-uri 'self'; upgrade-insecure-requests; block-all-mixed-content
< Vary: Origin
< Access-Control-Allow-Credentials: true
< Access-Control-Expose-Headers: Mcp-Protocol-Version,Mcp-Protocol-Id
< WWW-Authenticate: Bearer error="invalid_token", error_description="Missing Authorization header", resource_metadata="https://localhost:3232/.well-known/oauth-protected-resource"

^---- this one
````