### PR TITLE
fix: close per-request server and transport in example-apps handler

### DIFF
--- a/src/modules/example-apps/index.ts
+++ b/src/modules/example-apps/index.ts
@@ -133,6 +133,11 @@ export class ExampleAppsModule {
           sessionIdGenerator: undefined, // Stateless: no session management
         });
 
+        res.on('close', () => {
+          transport.close();
+          server.close();
+        });
+
         await server.connect(transport);
         await transport.handleRequest(req, res, req.body);
       } catch (error) {


### PR DESCRIPTION
## Summary
- The stateless `/:slug/mcp` handler in `src/modules/example-apps/index.ts` creates a fresh `McpServer` + `StreamableHTTPServerTransport` on every request but never closes either, so they accumulate until GC pressure stalls the process under sustained load.
- Register `res.on('close', ...)` to close both. Using `'close'` (rather than `'finish'`) ensures cleanup also runs when the client aborts mid-SSE-stream.

## Follow-up
- `src/modules/mcp/handlers/shttp.ts` uses `res.on('finish', ...)` for its cleanup, which does not fire on client abort. May warrant the same `'close'` treatment in a separate PR.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test` (79/79)