### PR TITLE
ci: add optional Cloud Run deploy job (gated on repo vars)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,3 +24,40 @@ jobs:
       - run: npm test
 
       - run: npm run lint
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main' && vars.GCP_PROJECT_ID != ''
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+
+      - id: deploy
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ vars.CLOUD_RUN_SERVICE }}
+          region: ${{ vars.CLOUD_RUN_REGION }}
+          source: .
+          env_vars: |-
+            BASE_URI=${{ vars.BASE_URI }}
+            NODE_ENV=production
+            REDIS_TLS=0
+          secrets: |-
+            REDIS_URL=REDIS_URL:latest
+          flags: |-
+            --vpc-connector=${{ vars.CLOUD_RUN_VPC_CONNECTOR }}
+            --service-account=${{ vars.CLOUD_RUN_SERVICE_ACCOUNT }}
+            --allow-unauthenticated
+            --min-instances=1
+            --max-instances=20
+            --concurrency=250
+            --memory=1Gi


### PR DESCRIPTION
## Summary

Adds a `deploy` job that ships to Cloud Run on push to `main`, **gated on `vars.GCP_PROJECT_ID`** so it's a no-op here and in forks. A downstream mirror can enable it by setting repo variables — no workflow diff to carry across rebases.

Includes `--memory=1Gi` (the 512Mi default sat at ~97% under load and caused multi-second GC stalls).

## Required repo variables (in the deploying mirror only)

| Variable | Example |
|---|---|
| `GCP_PROJECT_ID` | `mcp-server-everything` |
| `GCP_WIF_PROVIDER` | `projects/NNN/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider` |
| `CLOUD_RUN_SERVICE` | `mcp-server-everything` |
| `CLOUD_RUN_REGION` | `us-central1` |
| `BASE_URI` | `https://example-server.modelcontextprotocol.io/` |
| `CLOUD_RUN_VPC_CONNECTOR` | `redis-connector` |
| `CLOUD_RUN_SERVICE_ACCOUNT` | `cloudrun-service@PROJECT.iam.gserviceaccount.com` |

Also requires a `REDIS_URL` secret in GCP Secret Manager and a WIF provider configured to trust the deploying repo.

## Test plan
- [ ] CI on this PR: `deploy` job is skipped (condition false)
- [ ] In deploying mirror: set the 7 vars, merge, confirm Cloud Run revision deploys with 1Gi memory