### PR TITLE
chore: bump ext-apps + example servers to 1.7.1, sdk to 1.29.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.3.1",
-        "@modelcontextprotocol/sdk": "1.24.2",
+        "@modelcontextprotocol/sdk": "1.29.0",
         "@modelcontextprotocol/server-budget-allocator": "^1.3.1",
         "@modelcontextprotocol/server-cohort-heatmap": "^1.3.1",
         "@modelcontextprotocol/server-customer-segmentation": "^1.3.1",
@@ -1138,6 +1138,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1628,18 +1640,21 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/ext-apps": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.3.1.tgz",
-      "integrity": "sha512-XchYFGrCEO9JOLo6575MF3LWBrHOH9nVt1sC3ZaDL/JSgd6uN37/48Bcn5K1AIPXPxpsuQuczF8J+b4HxiYJpA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.1.tgz",
+      "integrity": "sha512-J3WdG1A4JSSKnSWKyU+895dBVYBV2Utgtf7fUsUK45mlkETm53a/1DR6Pm3hUGKqLLQthZLmpxOg8VPzJi/lyg==",
       "license": "MIT",
       "workspaces": [
         "examples/*"
       ],
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0"
+      },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "zod": "^3.25.0 || ^4.0.0"
@@ -1654,11 +1669,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.24.2.tgz",
-      "integrity": "sha512-hS/kzSfchqzvUeJUsdiDHi84/kNhLIZaZ6coGQVwbYIelOBbcAwUohUfaQTLa1MvFOK/jbTnGFzraHSFwB7pjQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1666,13 +1682,15 @@
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "jose": "^6.1.1",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.0"
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
@@ -1728,9 +1746,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1790,21 +1808,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
@@ -1968,13 +1971,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-budget-allocator": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-budget-allocator/-/server-budget-allocator-1.3.1.tgz",
-      "integrity": "sha512-+4kG0pE5KGGQwpm8XsuqGil26PsCEzut58JzT8bOidpzdkecbMZPMsjNaPcHUhK41PLbqcmAnLkGvyhXOkmegA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-budget-allocator/-/server-budget-allocator-1.7.1.tgz",
+      "integrity": "sha512-30BoouETrtNdU1NjY4MQzml8I4envyGD3DEmTFA3Tl2q22MwZuNyVBwPTU+96gPB3fqIWrhpEwg6M0GoFyG7Qg==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "chart.js": "^4.4.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -2256,13 +2259,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-cohort-heatmap": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-cohort-heatmap/-/server-cohort-heatmap-1.3.1.tgz",
-      "integrity": "sha512-/GwKpGNkWrF2iodDcpiPUNP8B598Wou4yqY4L3gC3Vn0kJKq21s57O7rnSy0ZXx58tbHNr+4NG9KjEs3DqNuzg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-cohort-heatmap/-/server-cohort-heatmap-1.7.1.tgz",
+      "integrity": "sha512-+dzWmUfO5vWLf0bUyGvMgEFuQ4/xXuBJz6I6UNf8I+3MrK5GJmZErrOeeIWQjgrZ/qow5oXOfvq3QFhsWNMf5w==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "react": "^19.2.0",
@@ -2545,13 +2548,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-customer-segmentation": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-customer-segmentation/-/server-customer-segmentation-1.3.1.tgz",
-      "integrity": "sha512-iYW8K24cBxpbDbUY+GY0he6p0KVkfHrnB/LJCk2PLJLr+li0FVgH70mtxNVcLvwjcO1Mn2yEyWIrrRTA6wIBfw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-customer-segmentation/-/server-customer-segmentation-1.7.1.tgz",
+      "integrity": "sha512-GFzyqBNSwetMEW6qWbKe75VkWa97yMxw6VfuyNSbswsSl/CAsjry5G1NcuocCjPzeh0oJA+csNpfexDTf9ezYA==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "chart.js": "^4.4.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -2833,13 +2836,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-debug": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-debug/-/server-debug-1.3.1.tgz",
-      "integrity": "sha512-MxyOqoKFBcLlUsYbvMYh/CnchYC+yHKeYZUpWj8lEocQ0omxEoiw3PA+Pj1E5TjbbRSwY0wT0/Srr58G8WMogQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-debug/-/server-debug-1.7.1.tgz",
+      "integrity": "sha512-D0WpATIs+upzOU60im2+fNCkN3F205tv5/aOYwoo8lr6e+0plHnPfEi2jufT5wnyJ2Xuef94QgjtSWArbac/QQ==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.1.13"
       },
       "bin": {
@@ -2856,13 +2859,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-map": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-map/-/server-map-1.3.1.tgz",
-      "integrity": "sha512-UriVi/x1j03QDL/zmnMEtixDszWGcyujlUsAcAvgn/mPObIJILwOSu8RvDlxUTKuoKrbu3xhH2B7LMfH04R93A==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-map/-/server-map-1.7.1.tgz",
+      "integrity": "sha512-gN4VzfssbeoiVwu22gZ8+gXcLcRisVa+EZCnfhIGpiT66hCkRkWn36BLKwWizu9e0L6mWqtcQ9uw7pez4g/fHQ==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "zod": "^4.1.13"
@@ -3143,13 +3146,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-pdf": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-pdf/-/server-pdf-1.3.1.tgz",
-      "integrity": "sha512-8eJVwX0dnFBOng4CK/BtpZZkTjWLVMxCRlOo/a/enH4puXNjcp7VKm5afetQH7GfHwrtQJ9lgdMpy04sIbRmzw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-pdf/-/server-pdf-1.7.1.tgz",
+      "integrity": "sha512-O4Sj+2IqLx9aEY4MBSpOZufPVw+Gqx5P/EEf9HMPGn9KDmnnbZ/NnTBYPwP06az7xKL2IVfR07m6YrZHiR0sjw==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "pdf-lib": "^1.17.1",
@@ -3432,13 +3435,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-scenario-modeler": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-scenario-modeler/-/server-scenario-modeler-1.3.1.tgz",
-      "integrity": "sha512-LTPOyTeET5rrg2uwJvngaVMJsNf1p3dNGS+ogGfa/Qk2m/6z+lpGjAKWdpm6i9BSQPYwo3yTmwDZfBJJ/hym8g==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-scenario-modeler/-/server-scenario-modeler-1.7.1.tgz",
+      "integrity": "sha512-68tf/fLnRHzovFK1/cdlSnekSu5NBSYtHFdBaoAVaroh54WmyPU6DFiWCP4Ab7bCDbuSW1JgJWCeba3QB7/9Hg==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "chart.js": "^4.4.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -3722,13 +3725,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-shadertoy": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-shadertoy/-/server-shadertoy-1.3.1.tgz",
-      "integrity": "sha512-8l1TRWVcFts+GXT+U9pJSlMd2yl3RIkQflBN6VDIWaG3Ou1+taJkoXxyLAYT63K4lB1oLf4YPDTlShxzgH7/+w==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-shadertoy/-/server-shadertoy-1.7.1.tgz",
+      "integrity": "sha512-5JiRHHVZ4F6vYjBrZ+E9GTgMo0WzC5Jui9NAlOJ6cNljgDZisIKSqTyBV2MUTSfR42JBvDOvS5Nddwns5+jhew==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "zod": "^4.1.13"
@@ -4009,13 +4012,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-sheet-music": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-sheet-music/-/server-sheet-music-1.3.1.tgz",
-      "integrity": "sha512-kekBFnM+yHidDYDmWqqjSkVrgQVLqAbNlxT4Q4MiaYV7dQqQcb50egDOIV26QWxQ5MqgXb0nqetIeibcAD5uBg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-sheet-music/-/server-sheet-music-1.7.1.tgz",
+      "integrity": "sha512-VVqweMyp/pqO0orBH3EAMlhF5fLxy0Gq3lfhGByfUgAdLMLRmPcCPagcFm4D0cp1XHEYs7C6osQ3ib+Hz/Tmbg==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "abcjs": "^6.4.4",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -4297,17 +4300,17 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-system-monitor": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-system-monitor/-/server-system-monitor-1.3.1.tgz",
-      "integrity": "sha512-rq+/PT8b/ovst3jPgCwGzFwxwy5vp3s4Qeddl6Ozxxt+MzYrZnMAUcy2pa2ap3W1o6y7Veei6ZOSLO5gv/QZRQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-system-monitor/-/server-system-monitor-1.7.1.tgz",
+      "integrity": "sha512-f3liwdTJsQILsmeph6okpZSIQynQA+5zK1A+tSEwnrw6/XGiawiiDk2sh95TNPZ3DxVVCNu1s63WGeoBhH1OzA==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "chart.js": "^4.4.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
-        "systeminformation": "^5.27.11",
+        "systeminformation": "^5.31.5",
         "zod": "^4.1.13"
       },
       "bin": {
@@ -4586,13 +4589,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-threejs": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-threejs/-/server-threejs-1.3.1.tgz",
-      "integrity": "sha512-2orMeJmsHN1rhvpFNJGzQwEMNaNTOml5TPMZw+z80cLC2h2Mllv2uHg90FhmeWqOBgVmzbIW6kH06FcCIhfasQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-threejs/-/server-threejs-1.7.1.tgz",
+      "integrity": "sha512-MUbTN56stZQmBrS7oQR6KE9Vlj1vQkUFipfao5iL4cpA09V1Uhp9RNK5mMM6fAlgZ4rAf9M7z5Gwc7bKyedKkA==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "react": "^19.2.0",
@@ -4876,13 +4879,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-transcript": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-transcript/-/server-transcript-1.3.1.tgz",
-      "integrity": "sha512-boGQL7hS+h9ehP+aprscrHPsjXMo1vf2d0lInUEMgLzwrGnHk2ThDEg7++Rs6UvN6vBOYb+cYw8fSKY8CQh8Ww==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-transcript/-/server-transcript-1.7.1.tgz",
+      "integrity": "sha512-Ewzyn+erELzucaGXQUEQ4hzwFUm43kBPawl+Pb6eqdhbU0dK/AvygaYTiCWysOwHwdc7Crhr10tLz6W0hkiaOg==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "zod": "^4.1.13"
@@ -5163,13 +5166,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-video-resource": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-video-resource/-/server-video-resource-1.3.1.tgz",
-      "integrity": "sha512-t5qYLBRTWGHrEhUpiKDvgoOLVs6Ao/2XrVIdRjooP4JzZzRtFgHT6pH7bQSluqr28XGhQbyyO6BmY9wAdlGOQw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-video-resource/-/server-video-resource-1.7.1.tgz",
+      "integrity": "sha512-Nmzl29htmjo3kE3CQg/tQVbulPFWQ8QzrgucKGxGJrxA3yg+iMBjwi/uLZLsXue8Zm3a82YAPn1gT5Oj3kinoQ==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "zod": "^4.1.13"
@@ -5450,13 +5453,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-wiki-explorer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-wiki-explorer/-/server-wiki-explorer-1.3.1.tgz",
-      "integrity": "sha512-EEHLQv+1Znnt8lyN4roFq8Hz1FbIcJCaj8/3PtCtgbk3W2+wFJqdiRKRzSHMxc3KW887LbvByy5Eh3GdKrMQDA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-wiki-explorer/-/server-wiki-explorer-1.7.1.tgz",
+      "integrity": "sha512-x/2qqSad6sqd0DVLeoC2rwckFYp7ea3dBF4LklT0TKC0VCb6gd/miUdJFH+U3fO1tgJK/596fsa/DJpGsRrdEw==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "cheerio": "^1.0.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -6334,6 +6337,12 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -6895,9 +6904,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -8211,9 +8220,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -8736,6 +8745,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/html-escaper": {
@@ -9637,9 +9655,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -9694,6 +9712,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -11256,9 +11280,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.30.4",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.30.4.tgz",
-      "integrity": "sha512-6Zi6NZRuEnK8Uv8R5s6+iz2NvamrxpYdpxhF7ANpzjlTfDRPQEJJh1cz2Car5KT+L1EWv6zGzECITKTinfL47g==",
+      "version": "5.31.5",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.5.tgz",
+      "integrity": "sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==",
       "license": "MIT",
       "os": [
         "darwin",
@@ -12333,12 +12357,12 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.25 || ^4"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^1.3.1",
-    "@modelcontextprotocol/sdk": "1.24.2",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@modelcontextprotocol/server-budget-allocator": "^1.3.1",
     "@modelcontextprotocol/server-cohort-heatmap": "^1.3.1",
     "@modelcontextprotocol/server-customer-segmentation": "^1.3.1",

--- a/src/modules/mcp/handlers/shttp.integration.test.ts
+++ b/src/modules/mcp/handlers/shttp.integration.test.ts
@@ -48,16 +48,32 @@ describe('Streamable HTTP Handler Integration Tests', () => {
       },
     } as unknown as Partial<Response>;
 
-    // Create mock request
+    // Create mock request. SDK 1.29 routes handleRequest through
+    // @hono/node-server which expects a real IncomingMessage shape, so
+    // the mock supplies the EventEmitter/stream surface hono touches.
     mockReq = {
       method: 'POST',
+      url: '/',
+      on: jest.fn(),
+      off: jest.fn(),
+      once: jest.fn(),
+      removeListener: jest.fn(),
+      resume: jest.fn(),
+      errored: null,
       headers: {
+        host: 'localhost',
         'content-type': 'application/json',
         'accept': 'application/json, text/event-stream',
         'mcp-protocol-version': '2024-11-05',
       },
       body: {},
-    };
+    } as unknown as Partial<Request>;
+    // Derive rawHeaders lazily so tests that mutate/replace `headers` stay in sync.
+    Object.defineProperty(mockReq, 'rawHeaders', {
+      get() {
+        return Object.entries(this.headers ?? {}).flatMap(([k, v]) => [k, String(v)]);
+      },
+    });
   });
 
   // Helper function to trigger cleanup after handleStreamableHTTP calls
@@ -83,7 +99,16 @@ describe('Streamable HTTP Handler Integration Tests', () => {
     if (sessionIdHeader?.[1]) {
       return sessionIdHeader[1] as string;
     }
-    
+
+    // SDK 1.29 writes headers via writeHead(status, headers) instead of setHeader
+    const writeHeadCalls = (mockRes.writeHead as jest.Mock).mock.calls;
+    for (const [, headers] of writeHeadCalls) {
+      if (headers && typeof headers === 'object') {
+        const id = (headers as Record<string, string>)['mcp-session-id'] ?? (headers as Record<string, string>)['Mcp-Session-Id'];
+        if (id) return id;
+      }
+    }
+
     // Fall back to extracting from Redis channels
     const allChannels = Array.from(mockRedis.subscribers.keys());
     const serverChannel = allChannels.find(channel => channel.includes('mcp:shttp:toserver:'));

--- a/src/modules/mcp/services/redisTransport.ts
+++ b/src/modules/mcp/services/redisTransport.ts
@@ -144,7 +144,7 @@ export async function redisRelayToMcpServer(sessionId: string, transport: Transp
     const messagePromise = new Promise<JSONRPCMessage>((resolve) => {
       transport.onmessage = async (message, extra) => {
         // First, set up response subscription if needed
-        if ("id" in message) {
+        if ("id" in message && message.id !== undefined) {
           logger.debug('Setting up response subscription', {
             sessionId,
             messageId: message.id,
@@ -289,7 +289,7 @@ export class ServerRedisTransport implements Transport {
   }
 
   async send(message: JSONRPCMessage, options?: TransportSendOptions): Promise<void> {
-    const relatedRequestId = options?.relatedRequestId?.toString() ?? ("id" in message ? message.id?.toString() : notificationStreamId);
+    const relatedRequestId = options?.relatedRequestId?.toString() ?? ("id" in message && message.id !== undefined ? message.id.toString() : notificationStreamId);
     const channel = getToClientChannel(this._sessionId, relatedRequestId)
 
     logger.debug('Sending message to client', {
@@ -336,13 +336,18 @@ export async function getShttpTransport(sessionId: string, onsessionclosed: (ses
     isGetRequest
   });
   
-  // Giving undefined here and setting the sessionId means the 
-  // transport wont try to create a new session.
+  // Inject the existing session ID so the transport resumes it instead of
+  // creating a new one. SDK 1.29 made sessionId readonly on the wrapper, but
+  // the underlying web-standard transport still exposes it as a writable field;
+  // _initialized must also be set so validateSession accepts non-init requests.
   const shttpTransport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: undefined,
+    sessionIdGenerator: () => sessionId,
     onsessionclosed,
   })
-  shttpTransport.sessionId = sessionId;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const inner = (shttpTransport as any)['_webStandardTransport'];
+  inner.sessionId = sessionId;
+  inner._initialized = true;
 
   // Use the new request-id based relay approach
   const cleanup = await redisRelayToMcpServer(sessionId, shttpTransport, isGetRequest);


### PR DESCRIPTION
## Summary

Updates the mounted MCP App example servers and `@modelcontextprotocol/ext-apps` to **1.7.1** ([release notes](https://github.com/modelcontextprotocol/ext-apps/releases/tag/v1.7.1)).

ext-apps@1.7.x peers on `@modelcontextprotocol/sdk ^1.29.0`, so this also bumps the pinned sdk from `1.24.2` → `1.29.0` and adapts to its `StreamableHTTPServerTransport` refactor (now wraps a web-standard transport via `@hono/node-server`).

## Code changes

- **`redisTransport.ts`** — `sessionId` is now a readonly getter on the Node wrapper; inject it (and `_initialized`) on the underlying web-standard transport so resumed sessions pass `validateSession`. Also guard `message.id`, which is now optional on `JSONRPCMessage`.
- **`shttp.integration.test.ts`** — `handleRequest` now routes through `@hono/node-server`, so the mock `IncomingMessage` needs `url`/`host`/`rawHeaders`/`on`/`off`/`resume`, and the `mcp-session-id` response header now arrives via `writeHead` instead of `setHeader`.

> [!NOTE]
> The `redisTransport` resume path reaches into the private `_webStandardTransport` field to set `sessionId` and `_initialized`. SDK 1.29 doesn't expose a public way to attach a pre-known session ID to a fresh transport (the previous approach of assigning `transport.sessionId` directly no longer compiles since it's now a getter). The underlying `WebStandardStreamableHTTPServerTransport.sessionId` *is* a public writable field — only the path to reach it is private. Worth raising upstream for a supported API; tracked as a follow-up.

## Test Plan

- `npm run build` ✅
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` — 79/79 ✅
- Smoke-tested `node dist/index.js` locally: `POST /pdf/mcp` and `POST /debug/mcp` both return valid `initialize` responses