### PR TITLE
Add lazy-auth example server (mounted at /lazy-auth)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@modelcontextprotocol/server-cohort-heatmap": "^1.3.1",
         "@modelcontextprotocol/server-customer-segmentation": "^1.3.1",
         "@modelcontextprotocol/server-debug": "^1.3.1",
+        "@modelcontextprotocol/server-lazy-auth": "https://pkg.pr.new/@modelcontextprotocol/server-lazy-auth@683",
         "@modelcontextprotocol/server-map": "^1.3.1",
         "@modelcontextprotocol/server-pdf": "^1.3.1",
         "@modelcontextprotocol/server-scenario-modeler": "^1.3.1",
@@ -1656,8 +1657,8 @@
     },
     "node_modules/@modelcontextprotocol/ext-apps": {
       "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.3.tgz",
-      "integrity": "sha512-IRBaqDtBZyiwv046FNbyFCIERPT5npu2lDSTCsiRL4se9+s7zcLjRxXlQ7dyD0IZnyS2VjturHftY8GAiDvldA==",
+      "resolved": "https://pkg.pr.new/modelcontextprotocol/ext-apps/@modelcontextprotocol/ext-apps@9110c2c",
+      "integrity": "sha512-Z9EajA2i1/U9BJ+OFVp3rBVsbasPKBy2EPDA0rnIB3s2/LLOrxbH2gUvlhpkdk3Xflryy49zwlW21LOhg0qxHA==",
       "license": "MIT",
       "workspaces": [
         "examples/*"
@@ -2871,6 +2872,301 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-lazy-auth": {
+      "version": "1.7.3",
+      "resolved": "https://pkg.pr.new/@modelcontextprotocol/server-lazy-auth@683",
+      "integrity": "sha512-1TqGMsjg4nXhJbPunMS1JRRtnGzT947gN+bui7JNJ11M1DBCHwUxjC7WXOBgWc1ZwfuHgjad3szawM9x6MHJ8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/ext-apps": "https://pkg.pr.new/modelcontextprotocol/ext-apps/@modelcontextprotocol/ext-apps@9110c2c",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "cors": "^2.8.5",
+        "express": "^5.1.0",
+        "jose": "^6.0.0"
+      },
+      "bin": {
+        "mcp-server-lazy-auth": "dist/index.js"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-lazy-auth/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-lazy-auth/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-lazy-auth/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-lazy-auth/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-lazy-auth/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-lazy-auth/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-lazy-auth/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-lazy-auth/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-lazy-auth/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-lazy-auth/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-lazy-auth/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-lazy-auth/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-lazy-auth/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-lazy-auth/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-lazy-auth/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-lazy-auth/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-lazy-auth/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@modelcontextprotocol/server-map": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -558,6 +558,21 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@cantoo/pdf-lib": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@cantoo/pdf-lib/-/pdf-lib-2.7.1.tgz",
+      "integrity": "sha512-oHVfp0JrHYodyF18dG1r85LStjJJs42LLoiu+elB9qZu9YfYoE66omF5hJ3gEKEXk6PPUUEDpBngeZiHMSnueQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "color": "^4.2.3",
+        "crypto-js": "^4.2.0",
+        "node-html-better-parser": ">=1.4.0",
+        "pako": "^1.0.11",
+        "tslib": ">=2"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.1",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.1.tgz",
@@ -1640,9 +1655,9 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/ext-apps": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.1.tgz",
-      "integrity": "sha512-J3WdG1A4JSSKnSWKyU+895dBVYBV2Utgtf7fUsUK45mlkETm53a/1DR6Pm3hUGKqLLQthZLmpxOg8VPzJi/lyg==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.3.tgz",
+      "integrity": "sha512-IRBaqDtBZyiwv046FNbyFCIERPT5npu2lDSTCsiRL4se9+s7zcLjRxXlQ7dyD0IZnyS2VjturHftY8GAiDvldA==",
       "license": "MIT",
       "workspaces": [
         "examples/*"
@@ -1971,12 +1986,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-budget-allocator": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-budget-allocator/-/server-budget-allocator-1.7.1.tgz",
-      "integrity": "sha512-30BoouETrtNdU1NjY4MQzml8I4envyGD3DEmTFA3Tl2q22MwZuNyVBwPTU+96gPB3fqIWrhpEwg6M0GoFyG7Qg==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-budget-allocator/-/server-budget-allocator-1.7.3.tgz",
+      "integrity": "sha512-VciLuJSWZkThWnvi/sWyo9/2BGBuSU1Epg8MpJdXCRbhc+JLuVxTNSxS4Iwq2lW+b/lYU9VMthyRcy7h4lkBbg==",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chart.js": "^4.4.0",
         "cors": "^2.8.5",
@@ -2259,12 +2274,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-cohort-heatmap": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-cohort-heatmap/-/server-cohort-heatmap-1.7.1.tgz",
-      "integrity": "sha512-+dzWmUfO5vWLf0bUyGvMgEFuQ4/xXuBJz6I6UNf8I+3MrK5GJmZErrOeeIWQjgrZ/qow5oXOfvq3QFhsWNMf5w==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-cohort-heatmap/-/server-cohort-heatmap-1.7.3.tgz",
+      "integrity": "sha512-pRs3McQ4Fw3co5fdBqogNpTgsMZs7grps6FrluvtIWyDpxTT1dCmR0+7wXV52hSzKd9ovBhbmRDLYCnutvaAUA==",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -2548,12 +2563,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-customer-segmentation": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-customer-segmentation/-/server-customer-segmentation-1.7.1.tgz",
-      "integrity": "sha512-GFzyqBNSwetMEW6qWbKe75VkWa97yMxw6VfuyNSbswsSl/CAsjry5G1NcuocCjPzeh0oJA+csNpfexDTf9ezYA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-customer-segmentation/-/server-customer-segmentation-1.7.3.tgz",
+      "integrity": "sha512-mGktrqxQKWbJG2TG5IamGk9MaJPfjfNn+X7yrg5FHto85pOIWjqyiL+NDs24/m/vtqG4G+yfDC+3LijAR+wPEQ==",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chart.js": "^4.4.0",
         "cors": "^2.8.5",
@@ -2836,12 +2851,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-debug": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-debug/-/server-debug-1.7.1.tgz",
-      "integrity": "sha512-D0WpATIs+upzOU60im2+fNCkN3F205tv5/aOYwoo8lr6e+0plHnPfEi2jufT5wnyJ2Xuef94QgjtSWArbac/QQ==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-debug/-/server-debug-1.7.3.tgz",
+      "integrity": "sha512-skVrSKntL3mjTGuCM4YHwWYqqNftwVdOBi76dU+jtTj6r4kdN7e1HjVsXa5v3I311oI2oXmJgxyR8xK7qd+FBg==",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.1.13"
       },
@@ -2859,12 +2874,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-map": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-map/-/server-map-1.7.1.tgz",
-      "integrity": "sha512-gN4VzfssbeoiVwu22gZ8+gXcLcRisVa+EZCnfhIGpiT66hCkRkWn36BLKwWizu9e0L6mWqtcQ9uw7pez4g/fHQ==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-map/-/server-map-1.7.3.tgz",
+      "integrity": "sha512-Zhk/GzdPWSsVLq9sMWwStVXh2CNglrtef5g4wmE3l4vHv6wgIXVg2mA46fNwWezUyUdok3Nv5oU+SApvNDhG8A==",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -3146,16 +3161,16 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-pdf": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-pdf/-/server-pdf-1.7.1.tgz",
-      "integrity": "sha512-O4Sj+2IqLx9aEY4MBSpOZufPVw+Gqx5P/EEf9HMPGn9KDmnnbZ/NnTBYPwP06az7xKL2IVfR07m6YrZHiR0sjw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-pdf/-/server-pdf-1.7.3.tgz",
+      "integrity": "sha512-tywbM4xw2SSjOmpIfLFKh6pDTMcAjbvpYShVzsObQ++vMYUnpAqhf4rsClHt9ai4C3Vp2/9UzJEl5j2Xgk40KQ==",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@cantoo/pdf-lib": "^2.6.5",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
-        "pdf-lib": "^1.17.1",
         "pdfjs-dist": "^5.0.0",
         "zod": "^4.1.13"
       },
@@ -3435,12 +3450,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-scenario-modeler": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-scenario-modeler/-/server-scenario-modeler-1.7.1.tgz",
-      "integrity": "sha512-68tf/fLnRHzovFK1/cdlSnekSu5NBSYtHFdBaoAVaroh54WmyPU6DFiWCP4Ab7bCDbuSW1JgJWCeba3QB7/9Hg==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-scenario-modeler/-/server-scenario-modeler-1.7.3.tgz",
+      "integrity": "sha512-CK2U2Cequ9ldbc0jFrSaxZvHEidEnSIKuZHfQRGo/YARvmJYyAyhDpU9EYBhPmmBbeM1O6TUOcPvvBrtFpQa8Q==",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chart.js": "^4.4.0",
         "cors": "^2.8.5",
@@ -3725,12 +3740,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-shadertoy": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-shadertoy/-/server-shadertoy-1.7.1.tgz",
-      "integrity": "sha512-5JiRHHVZ4F6vYjBrZ+E9GTgMo0WzC5Jui9NAlOJ6cNljgDZisIKSqTyBV2MUTSfR42JBvDOvS5Nddwns5+jhew==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-shadertoy/-/server-shadertoy-1.7.3.tgz",
+      "integrity": "sha512-qo6y2Tz9PZ+6S7oyZMBaZjsg4EtAqVn0KCOBPO+tfVUBNalz+yBldq2JYJ/WSEyyPiLyOcdpzdOgNeA/QYHDOQ==",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -4012,12 +4027,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-sheet-music": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-sheet-music/-/server-sheet-music-1.7.1.tgz",
-      "integrity": "sha512-VVqweMyp/pqO0orBH3EAMlhF5fLxy0Gq3lfhGByfUgAdLMLRmPcCPagcFm4D0cp1XHEYs7C6osQ3ib+Hz/Tmbg==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-sheet-music/-/server-sheet-music-1.7.3.tgz",
+      "integrity": "sha512-GpYiVWCml8ln9VhofpOAxBx/VuwflX9Q+Z7N/hp/6ayt1XqNOOuXg2+XbeB6Oh4A3x2/i0TiyQBhv8bRDApKNQ==",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "abcjs": "^6.4.4",
         "cors": "^2.8.5",
@@ -4300,12 +4315,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-system-monitor": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-system-monitor/-/server-system-monitor-1.7.1.tgz",
-      "integrity": "sha512-f3liwdTJsQILsmeph6okpZSIQynQA+5zK1A+tSEwnrw6/XGiawiiDk2sh95TNPZ3DxVVCNu1s63WGeoBhH1OzA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-system-monitor/-/server-system-monitor-1.7.3.tgz",
+      "integrity": "sha512-S1axqhvP6kKEgMxTfPkpweEHNgVT7QnCXI4Un+y3PLlAM6RLYbwD1d7VOUM0HHB9tTYerUtE/Zqn3zUf8rJG7w==",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chart.js": "^4.4.0",
         "cors": "^2.8.5",
@@ -4589,12 +4604,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-threejs": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-threejs/-/server-threejs-1.7.1.tgz",
-      "integrity": "sha512-MUbTN56stZQmBrS7oQR6KE9Vlj1vQkUFipfao5iL4cpA09V1Uhp9RNK5mMM6fAlgZ4rAf9M7z5Gwc7bKyedKkA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-threejs/-/server-threejs-1.7.3.tgz",
+      "integrity": "sha512-eO5LpAFR92BodZ0ZBD0CbxmZTvpwxS2PbQSeyw68AkDYD1OaSodkAgzodsr1vrh9+0PgS6KMPOwqPrqPNVwKcw==",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -4879,9 +4894,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-transcript": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-transcript/-/server-transcript-1.7.1.tgz",
-      "integrity": "sha512-Ewzyn+erELzucaGXQUEQ4hzwFUm43kBPawl+Pb6eqdhbU0dK/AvygaYTiCWysOwHwdc7Crhr10tLz6W0hkiaOg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-transcript/-/server-transcript-1.7.2.tgz",
+      "integrity": "sha512-YLPoztr+XVf/dNpbGYbWHkKniVx5BPjVIsT+TfaJLEQDqxFBzvJUjewKLRrbaBZ72ZE3/sCl6ldomMX7Iuo+xA==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -5166,12 +5181,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-video-resource": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-video-resource/-/server-video-resource-1.7.1.tgz",
-      "integrity": "sha512-Nmzl29htmjo3kE3CQg/tQVbulPFWQ8QzrgucKGxGJrxA3yg+iMBjwi/uLZLsXue8Zm3a82YAPn1gT5Oj3kinoQ==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-video-resource/-/server-video-resource-1.7.3.tgz",
+      "integrity": "sha512-NRK1pmH2HLRgWbgmOe3noFlXXP+DD8KESz5f4yTYPDzDRyPF0M6pw0dt4RGKF5DAqXIcXqo1VAlEew27o15FMQ==",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -5453,12 +5468,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-wiki-explorer": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-wiki-explorer/-/server-wiki-explorer-1.7.1.tgz",
-      "integrity": "sha512-x/2qqSad6sqd0DVLeoC2rwckFYp7ea3dBF4LklT0TKC0VCb6gd/miUdJFH+U3fO1tgJK/596fsa/DJpGsRrdEw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-wiki-explorer/-/server-wiki-explorer-1.7.3.tgz",
+      "integrity": "sha512-lxgikBfZe2g6gGLmeDcG0yvNWTWZdMbrKIrfwm5ujIrf/If/Vn2SOjsfuvCtX7HVd+Xy5N5Chc1aWhO/BHgevw==",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cheerio": "^1.0.0",
         "cors": "^2.8.5",
@@ -7486,11 +7501,23 @@
       "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
       "dev": true
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -7501,8 +7528,17 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -7620,6 +7656,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/css-select": {
       "version": "5.2.2",
@@ -8755,6 +8797,22 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -10032,6 +10090,15 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "node_modules/node-html-better-parser": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/node-html-better-parser/-/node-html-better-parser-1.5.8.tgz",
+      "integrity": "sha512-t/wAKvaTSKco43X+yf9+76RiMt18MtMmzd4wc7rKj+fWav6DV4ajDEKdWlLzSE8USDF5zr/06uGj0Wr/dGAFtw==",
+      "license": "MIT",
+      "dependencies": {
+        "html-entities": "^2.3.2"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -10318,24 +10385,6 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
-    },
-    "node_modules/pdf-lib": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
-      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
-      "license": "MIT",
-      "dependencies": {
-        "@pdf-lib/standard-fonts": "^1.0.0",
-        "@pdf-lib/upng": "^1.0.1",
-        "pako": "^1.0.11",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/pdf-lib/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
     },
     "node_modules/pdfjs-dist": {
       "version": "5.4.530",
@@ -11099,6 +11148,21 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -11496,8 +11560,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@modelcontextprotocol/server-cohort-heatmap": "^1.3.1",
     "@modelcontextprotocol/server-customer-segmentation": "^1.3.1",
     "@modelcontextprotocol/server-debug": "^1.3.1",
+    "@modelcontextprotocol/server-lazy-auth": "https://pkg.pr.new/@modelcontextprotocol/server-lazy-auth@683",
     "@modelcontextprotocol/server-map": "^1.3.1",
     "@modelcontextprotocol/server-pdf": "^1.3.1",
     "@modelcontextprotocol/server-scenario-modeler": "^1.3.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { config } from './config.js';
 import { AuthModule } from './modules/auth/index.js';
 import { MCPModule } from './modules/mcp/index.js';
 import { ExampleAppsModule, AVAILABLE_EXAMPLES } from './modules/example-apps/index.js';
+import { mountLazyAuthExample } from './modules/example-apps/lazy-auth.js';
 import { ExternalTokenValidator, InternalTokenValidator, ITokenValidator } from './interfaces/auth-validator.js';
 import { redisClient } from './modules/shared/redis.js';
 import { logger } from './modules/shared/logger.js';
@@ -47,6 +48,13 @@ async function main() {
   // Trust proxy headers (X-Forwarded-For, etc.) when behind reverse proxy (Cloudflare, etc.)
   // This is required for rate limiting to work correctly with real client IPs
   app.set('trust proxy', true);
+
+  // Lazy-auth MCP App example: a full Express app with its own mock OAuth
+  // authorization server, mounted at /lazy-auth. Registered before the host
+  // middleware so its CORS and body handling stay self-contained.
+  if (config.auth.mode !== 'auth_server') {
+    mountLazyAuthExample(app, config.baseUri);
+  }
 
   // Basic middleware
   // Intentionally permissive CORS for public MCP reference server

--- a/src/modules/example-apps/index.ts
+++ b/src/modules/example-apps/index.ts
@@ -33,6 +33,8 @@ import { createServer as createTranscriptServer } from '@modelcontextprotocol/se
 import { createServer as createVideoResourceServer } from '@modelcontextprotocol/server-video-resource';
 import { createServer as createWikiExplorerServer } from '@modelcontextprotocol/server-wiki-explorer';
 
+import { LAZY_AUTH_SLUG } from './lazy-auth.js';
+
 declare module "express-serve-static-core" {
   interface Request {
     auth?: AuthInfo;
@@ -161,5 +163,8 @@ export class ExampleAppsModule {
   }
 }
 
-// Export list of available examples for documentation
-export const AVAILABLE_EXAMPLES = Object.keys(EXAMPLE_SERVERS);
+// Export list of available examples for documentation. The lazy-auth example
+// is served at the same /:slug/mcp path shape, but as a full Express app with
+// its own OAuth endpoints rather than through the stateless handler above
+// (see ./lazy-auth.ts).
+export const AVAILABLE_EXAMPLES = [...Object.keys(EXAMPLE_SERVERS), LAZY_AUTH_SLUG];

--- a/src/modules/example-apps/lazy-auth.integration.test.ts
+++ b/src/modules/example-apps/lazy-auth.integration.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Integration tests for the lazy-auth example mount.
+ *
+ * Verifies that the @modelcontextprotocol/server-lazy-auth app, mounted at
+ * /lazy-auth, advertises URLs under the mount path, that RFC 8414/9728
+ * path-insertion well-known URLs at the host root reach the example, that the
+ * host's own root OAuth endpoints are untouched, and that the full lazy-auth
+ * flow (401 -> discovery -> PKCE -> token -> authed tool call) works
+ * end-to-end over HTTP.
+ */
+import { createHash } from 'crypto';
+import http from 'http';
+import express from 'express';
+import { AddressInfo } from 'net';
+import { mountLazyAuthExample } from './lazy-auth.js';
+
+interface HttpResult {
+  status: number;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+}
+
+function request(url: string, options: http.RequestOptions = {}, body?: string): Promise<HttpResult> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(url, options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => resolve({ status: res.statusCode ?? 0, headers: res.headers, body: data }));
+    });
+    req.on('error', reject);
+    if (body !== undefined) req.write(body);
+    req.end();
+  });
+}
+
+function callTool(base: string, name: string, accessToken?: string): Promise<HttpResult> {
+  return request(
+    `${base}/lazy-auth/mcp`,
+    {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        ...(accessToken ? { authorization: `Bearer ${accessToken}` } : {}),
+      },
+    },
+    JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name, arguments: {} } })
+  );
+}
+
+describe('Lazy Auth example mount', () => {
+  let server: http.Server;
+  let base: string;
+
+  beforeAll(async () => {
+    const app = express();
+    // Mirror src/index.ts: the example mounts before the host's middleware
+    // and routes.
+    mountLazyAuthExample(app);
+    app.use(express.json());
+    // Sentinels for the host's own root OAuth surface, which the example's
+    // well-known rewrite must not shadow.
+    app.get('/.well-known/oauth-authorization-server', (_req, res) => {
+      res.json({ issuer: 'HOST-OWN-AS' });
+    });
+    app.get('/authorize', (_req, res) => {
+      res.send('HOST-OWN-AUTHORIZE');
+    });
+
+    server = await new Promise((resolve) => {
+      const s = app.listen(0, () => resolve(s));
+    });
+    base = `http://localhost:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  it('serves public MCP requests without auth', async () => {
+    const res = await request(
+      `${base}/lazy-auth/mcp`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+      },
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'test', version: '0' } },
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toContain('Lazy Auth');
+  });
+
+  it('answers 401 with resource_metadata under the mount path for protected tools', async () => {
+    const res = await callTool(base, 'get_secret');
+    expect(res.status).toBe(401);
+    expect(res.headers['www-authenticate']).toContain(`resource_metadata="${base}/lazy-auth/auth/prm"`);
+  });
+
+  it('advertises mount-prefixed URLs in PRM and AS metadata', async () => {
+    const prm = JSON.parse((await request(`${base}/lazy-auth/auth/prm`)).body);
+    expect(prm.resource).toBe(`${base}/lazy-auth/mcp`);
+    expect(prm.authorization_servers).toEqual([`${base}/lazy-auth`]);
+
+    // RFC 8414 path-insertion form at the host root (the only form MCP SDK
+    // clients try for an issuer with a path).
+    const asRes = await request(`${base}/.well-known/oauth-authorization-server/lazy-auth`);
+    expect(asRes.status).toBe(200);
+    const as = JSON.parse(asRes.body);
+    expect(as.issuer).toBe(`${base}/lazy-auth`);
+    expect(as.authorization_endpoint).toBe(`${base}/lazy-auth/authorize`);
+    expect(as.token_endpoint).toBe(`${base}/lazy-auth/token`);
+  });
+
+  it('serves TTL-scoped PRM through the path-insertion form', async () => {
+    const res = await request(`${base}/.well-known/oauth-protected-resource/lazy-auth/ttl/3600/mcp`);
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body).resource).toBe(`${base}/lazy-auth/ttl/3600/mcp`);
+  });
+
+  it('leaves the host root OAuth surface untouched', async () => {
+    const as = await request(`${base}/.well-known/oauth-authorization-server`);
+    expect(JSON.parse(as.body).issuer).toBe('HOST-OWN-AS');
+    const authorize = await request(`${base}/authorize`);
+    expect(authorize.body).toBe('HOST-OWN-AUTHORIZE');
+  });
+
+  it('completes the full lazy-auth flow: PKCE -> token -> authed tool call', async () => {
+    const verifier = 'v'.repeat(43);
+    const challenge = createHash('sha256').update(verifier).digest('base64url');
+
+    const authorizeUrl = new URL(`${base}/lazy-auth/authorize`);
+    const params: Record<string, string> = {
+      client_id: 'test-client',
+      redirect_uri: 'http://localhost:1234/callback',
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+      state: 'test-state',
+      approved: '1',
+      resource: `${base}/lazy-auth/mcp`,
+    };
+    for (const [k, v] of Object.entries(params)) authorizeUrl.searchParams.set(k, v);
+
+    const authorizeRes = await request(authorizeUrl.href);
+    expect(authorizeRes.status).toBe(302);
+    const redirect = new URL(authorizeRes.headers.location!);
+    const code = redirect.searchParams.get('code')!;
+    expect(code).toBeTruthy();
+    expect(redirect.searchParams.get('state')).toBe('test-state');
+
+    const tokenRes = await request(
+      `${base}/lazy-auth/token`,
+      { method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded' } },
+      new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        code_verifier: verifier,
+        resource: `${base}/lazy-auth/mcp`,
+      }).toString()
+    );
+    expect(tokenRes.status).toBe(200);
+    const token = JSON.parse(tokenRes.body);
+    expect(token.access_token).toBeTruthy();
+    expect(token.refresh_token).toBeTruthy();
+
+    const secretRes = await callTool(base, 'get_secret', token.access_token);
+    expect(secretRes.status).toBe(200);
+    expect(secretRes.body).toContain('the-answer-is-42');
+  });
+});

--- a/src/modules/example-apps/lazy-auth.ts
+++ b/src/modules/example-apps/lazy-auth.ts
@@ -1,0 +1,51 @@
+/**
+ * Lazy Auth Example - Mounts @modelcontextprotocol/server-lazy-auth at /lazy-auth
+ *
+ * Unlike the other example servers (plain createServer() factories in
+ * ./index.ts), the lazy-auth example's whole point is its HTTP layer: public
+ * tools work unauthenticated, protected tools answer 401 + WWW-Authenticate,
+ * and a built-in mock OAuth authorization server completes the flow. So we
+ * mount its full Express app under /lazy-auth instead of adding it to the
+ * generic stateless handler.
+ *
+ * Call mountLazyAuthExample() BEFORE registering the host's own middleware
+ * (CORS, body parsing, logging) so the example's responses stay fully
+ * self-contained, and before any other /.well-known routes.
+ *
+ * The example advertises absolute OAuth URLs (issuer, authorize/token
+ * endpoints, PRM resource, WWW-Authenticate resource_metadata). It resolves
+ * them from PUBLIC_URL, falling back to the request Host header for loopback
+ * hosts only. We derive PUBLIC_URL from this server's own public base URI -
+ * already the source of truth for the host's OAuth issuer - so deployments
+ * need no separate env var. An explicit PUBLIC_URL still wins (e.g. a tunnel);
+ * omitting baseUri (e.g. tests on an ephemeral port) keeps the package's
+ * per-request Host resolution.
+ */
+import { Express, Request, Response, NextFunction } from 'express';
+import { createApp as createLazyAuthApp } from '@modelcontextprotocol/server-lazy-auth';
+
+export const LAZY_AUTH_SLUG = 'lazy-auth';
+
+export function mountLazyAuthExample(app: Express, baseUri?: string): void {
+  if (baseUri && !process.env.PUBLIC_URL) {
+    process.env.PUBLIC_URL = `${baseUri.replace(/\/+$/, '')}/${LAZY_AUTH_SLUG}`;
+  }
+
+  // RFC 8414/9728 place well-known discovery documents at the origin root,
+  // with the resource path inserted after the well-known prefix
+  // (e.g. /.well-known/oauth-authorization-server/lazy-auth), and MCP SDK
+  // clients only try that insertion form. Rewrite those root paths into the
+  // mount - rather than dispatching to the sub-app directly - so req.baseUrl
+  // (and therefore every URL the example advertises) stays consistent.
+  app.use((req: Request, _res: Response, next: NextFunction) => {
+    const wellKnown = req.url.match(
+      /^\/\.well-known\/(oauth-authorization-server|oauth-protected-resource)\/lazy-auth(\/.*)?$/
+    );
+    if (wellKnown) {
+      req.url = `/${LAZY_AUTH_SLUG}/.well-known/${wellKnown[1]}${wellKnown[2] ?? ''}`;
+    }
+    next();
+  });
+
+  app.use(`/${LAZY_AUTH_SLUG}`, createLazyAuthApp());
+}


### PR DESCRIPTION
## What this does

Adds the `@modelcontextprotocol/server-lazy-auth` example, served at `/lazy-auth/mcp` alongside the other example MCP App servers, and bumps the ext-apps example family to 1.7.3.

Unlike the other examples (plain `createServer()` factories behind the stateless handler), lazy-auth's value is its HTTP layer — public tools work unauthenticated; protected tools answer `401` + `WWW-Authenticate`; a built-in mock OAuth authorization server completes the flow. So it mounts its full Express app (`createApp()`) under `/lazy-auth`.

## Why now / what's blocked without it

The mobile clauditor e2e specs are blocked on reaching lazy-auth at `https://example-server.modelcontextprotocol.io/lazy-auth/ttl/3600/mcp` (TTL-scoped path → 1-hour tokens, so 30s defaults don't expire mid-test on slow mobile runs).

## What changed

- **`src/modules/example-apps/lazy-auth.ts`** — mounts the app before the host middleware, and adds the RFC 8414/9728 *path-insertion* well-known rewrite (`/.well-known/oauth-authorization-server/lazy-auth` → into the mount). MCP SDK clients only try the insertion form for `oauth-authorization-server`, so this rewrite is required for discovery under a base path.
- **`src/index.ts` / `example-apps/index.ts`** — early mount (so the example's CORS/body handling stay self-contained), splash + console listings.
- **No new deploy config**: `PUBLIC_URL` for the example is derived from this server's own `BASE_URI` (already the source of truth for the host's OAuth issuer). An explicit `PUBLIC_URL` still wins (e.g. a tunnel). Tests on an ephemeral port fall back to the package's per-request Host resolution.
- **Integration test** covering the full flow: public `initialize`/`tools/list`, `401` on the protected tool, mount-prefixed discovery metadata, TTL-path PRM, and the PKCE → token → authed `get_secret` round trip.

## How we know it works

- `npm run build`, `npm run lint`, `npm test` all green (7 suites / 85 tests, lazy-auth integration included), verified in a linux container matching CI.
- Driven additionally with the real `@modelcontextprotocol/sdk@1.29.0` client discovery machinery (`extractResourceMetadataUrl` → PRM → `buildDiscoveryUrls` → `auth()` with PKCE) — full discovery + auth + silent refresh pass, on both `/lazy-auth/mcp` and `/lazy-auth/ttl/3600/mcp`.
- Prod-like boot (`BASE_URI=https://example-server.modelcontextprotocol.io/`, no `PUBLIC_URL`) advertises correct mount-prefixed OAuth URLs, trailing slash normalized.

## ⚠️ Draft: blocked on a release

The base-path mount support is **not yet in a published release** of `server-lazy-auth`. This branch temporarily pins the dependency to the merged-PR preview build (`pkg.pr.new`, from [modelcontextprotocol/ext-apps#683](https://github.com/modelcontextprotocol/ext-apps/pull/683)) so CI runs against the real code. Before merge, the finishing commit flips both `server-lazy-auth` and `ext-apps` to the registry `^<release>` and regenerates the lockfile against npmjs.

Depends on: ext-apps#683 (merged) → next ext-apps release.
