### PR TITLE
Clean up session ownership keys in Redis

### DIFF
--- a/src/modules/mcp/services/redisTransport.test.ts
+++ b/src/modules/mcp/services/redisTransport.test.ts
@@ -297,6 +297,52 @@ describe('Redis Transport', () => {
       expect(await validateSessionOwnership(sessionId, 'different-user')).toBe(false);
     });
 
+    it('should set the ownership key with a TTL', async () => {
+      const setSpy = jest.spyOn(mockRedis, 'set');
+
+      await setSessionOwner(sessionId, userId);
+
+      expect(setSpy).toHaveBeenCalledWith(
+        `session:${sessionId}:owner`,
+        userId,
+        expect.objectContaining({ EX: expect.any(Number) })
+      );
+    });
+
+    it('should refresh the ownership TTL on successful validation only', async () => {
+      const expireSpy = jest.spyOn(mockRedis, 'expire');
+      await setSessionOwner(sessionId, userId);
+
+      expect(await validateSessionOwnership(sessionId, userId)).toBe(true);
+      expect(expireSpy).toHaveBeenCalledWith(`session:${sessionId}:owner`, expect.any(Number));
+
+      expireSpy.mockClear();
+      expect(await validateSessionOwnership(sessionId, 'different-user')).toBe(false);
+      expect(expireSpy).not.toHaveBeenCalled();
+    });
+
+    it('should remove the ownership key when the server transport closes', async () => {
+      await setSessionOwner(sessionId, userId);
+      expect(await getSessionOwner(sessionId)).toBe(userId);
+
+      const transport = new ServerRedisTransport(sessionId);
+      await transport.start();
+      await transport.close();
+
+      expect(await getSessionOwner(sessionId)).toBeNull();
+    });
+
+    it('should remove the ownership key when the session is shut down via control message', async () => {
+      await setSessionOwner(sessionId, userId);
+
+      const transport = new ServerRedisTransport(sessionId);
+      await transport.start();
+      await shutdownSession(sessionId);
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(await getSessionOwner(sessionId)).toBeNull();
+    });
+
     it('should check if session is owned by user including liveness', async () => {
       // Session not live yet
       expect(await isSessionOwnedBy(sessionId, userId)).toBe(false);

--- a/src/modules/mcp/services/redisTransport.ts
+++ b/src/modules/mcp/services/redisTransport.ts
@@ -8,6 +8,11 @@ import { logger } from "../../shared/logger.js";
 let redisTransportCounter = 0;
 const notificationStreamId = "__GET_stream";
 
+// Safety-net TTL for session ownership keys. Live sessions refresh it on every
+// authorized request, and ServerRedisTransport.close() deletes the key, so the
+// TTL only ever fires for keys orphaned by a crashed process.
+const SESSION_OWNER_TTL_SECONDS = 30 * 60;
+
 // Message types for Redis transport
 type RedisMessage = 
   | {
@@ -69,18 +74,33 @@ export async function isLive(sessionId: string): Promise<boolean> {
   return numSubs > 0;
 }
 
+function getSessionOwnerKey(sessionId: string): string {
+  return `session:${sessionId}:owner`;
+}
+
 export async function setSessionOwner(sessionId: string, userId: string): Promise<void> {
   logger.debug('Setting session owner', { sessionId, userId });
-  await redisClient.set(`session:${sessionId}:owner`, userId);
+  await redisClient.set(getSessionOwnerKey(sessionId), userId, { EX: SESSION_OWNER_TTL_SECONDS });
 }
 
 export async function getSessionOwner(sessionId: string): Promise<string | null> {
-  return await redisClient.get(`session:${sessionId}:owner`);
+  return await redisClient.get(getSessionOwnerKey(sessionId));
+}
+
+export async function deleteSessionOwner(sessionId: string): Promise<void> {
+  logger.debug('Deleting session owner', { sessionId });
+  await redisClient.del(getSessionOwnerKey(sessionId));
 }
 
 export async function validateSessionOwnership(sessionId: string, userId: string): Promise<boolean> {
   const owner = await getSessionOwner(sessionId);
-  return owner === userId;
+  if (owner !== userId) {
+    return false;
+  }
+  // Sliding expiration: each authorized request keeps the ownership key alive,
+  // so the TTL only reaps keys whose session never got cleaned up.
+  await redisClient.expire(getSessionOwnerKey(sessionId), SESSION_OWNER_TTL_SECONDS);
+  return true;
 }
 
 export async function isSessionOwnedBy(sessionId: string, userId: string): Promise<boolean> {
@@ -325,7 +345,10 @@ export class ServerRedisTransport implements Transport {
       await this.controlCleanup();
       this.controlCleanup = undefined;
     }
-    
+
+    // The session is finished — remove its ownership key (#21)
+    await deleteSessionOwner(this._sessionId);
+
     this.onclose?.();
   }
 }


### PR DESCRIPTION
Fixes #21.

`session:${sessionId}:owner` keys were written without a TTL and never deleted when the transport was cleaned up, so they accumulated in Redis indefinitely.

Two complementary changes:

1. **Deterministic cleanup**: `ServerRedisTransport.close()` now deletes the session's ownership key. `close()` runs on every session-termination path — client `DELETE` (`onsessionclosed` → `shutdownSession`), `SHUTDOWN` control messages, and the 5-minute inactivity timeout — so a finished session always removes its key.
2. **Safety-net TTL**: `setSessionOwner` now sets a 30-minute `EX` on the key, and `validateSessionOwnership` refreshes it on each successful (authorized) check. Live sessions therefore never expire mid-flight — every request slides the TTL — while keys orphaned by a crashed process (where `close()` never ran) still get reaped by Redis.

The TTL refresh happens only on successful validation, so an attacker probing someone else's session id can't keep a foreign key alive.

Added unit tests covering: TTL set on write, TTL refresh on authorized validation only, key removal on transport close, and key removal via SHUTDOWN control message. `npm run build`, `npx eslint` on the touched files, and the full jest suite (83 tests, 6 suites) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)