### PR TITLE
Serve OAuth protected resource metadata (RFC 9728) on the MCP server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,9 +70,44 @@ async function main() {
     }
   }
 
-  // OAuth metadata discovery endpoint
+  // OAuth metadata discovery endpoints
   // Only served by MCP servers (not standalone auth servers)
   if (config.auth.mode !== 'auth_server') {
+    // Determine the auth server URL based on mode
+    const authServerUrl = config.auth.mode === 'internal'
+      ? config.baseUri  // Internal mode: auth is in same process
+      : config.auth.externalUrl!;  // External mode: separate auth server
+
+    // OAuth 2.0 Protected Resource Metadata (RFC 9728)
+    // This is what the MCP spec requires the *resource server* to expose: the
+    // bearer-auth middleware advertises this URL in the WWW-Authenticate header
+    // of 401 responses, and clients follow it to discover the authorization
+    // server. Served at the root well-known path (advertised in 401s) and at
+    // the path-suffixed variant for the /mcp endpoint (RFC 9728 §3.1 path
+    // insertion, for clients that derive the URL from the endpoint themselves).
+    const protectedResourceHandler = (resource: string) => (req: express.Request, res: express.Response) => {
+      logger.info('OAuth protected resource metadata discovery', {
+        userAgent: req.get('user-agent'),
+        authMode: config.auth.mode,
+        ip: req.ip
+      });
+
+      res.json({
+        resource,
+        resource_name: 'MCP Feature Reference Server',
+        authorization_servers: [authServerUrl],
+        bearer_methods_supported: ['header'],
+        service_documentation: 'https://modelcontextprotocol.io'
+      });
+    };
+    app.get('/.well-known/oauth-protected-resource', protectedResourceHandler(config.baseUri));
+    app.get('/.well-known/oauth-protected-resource/mcp', protectedResourceHandler(`${config.baseUri}/mcp`));
+
+    // OAuth 2.0 Authorization Server Metadata (RFC 8414), kept on the MCP
+    // server for backwards compatibility: clients of the 2025-03-26 revision
+    // of the MCP spec discover auth by querying this path on the MCP server
+    // directly. In external mode it proxies the metadata shape of the
+    // external auth server's endpoints.
     app.get('/.well-known/oauth-authorization-server', (req, res) => {
       // Log the metadata discovery request
       logger.info('OAuth metadata discovery', {
@@ -80,11 +115,6 @@ async function main() {
         authMode: config.auth.mode,
         ip: req.ip
       });
-
-      // Determine the auth server URL based on mode
-      const authServerUrl = config.auth.mode === 'internal'
-        ? config.baseUri  // Internal mode: auth is in same process
-        : config.auth.externalUrl!;  // External mode: separate auth server
 
       res.json({
         issuer: authServerUrl,
@@ -181,7 +211,8 @@ async function main() {
     console.log('MCP Endpoints:');
     console.log(`   Streamable HTTP: ${config.baseUri}/mcp`);
     console.log(`   SSE (legacy): ${config.baseUri}/sse`);
-    console.log(`   OAuth Metadata: ${config.baseUri}/.well-known/oauth-authorization-server`);
+    console.log(`   Protected Resource Metadata: ${config.baseUri}/.well-known/oauth-protected-resource`);
+    console.log(`   OAuth Metadata (legacy): ${config.baseUri}/.well-known/oauth-authorization-server`);
     console.log('');
     console.log('MCP App Example Servers:');
     for (const slug of AVAILABLE_EXAMPLES) {


### PR DESCRIPTION
Fixes #22.

The MCP module's `requireBearerAuth` already advertises a `resource_metadata` URL in 401 `WWW-Authenticate` headers (via `getOAuthProtectedResourceMetadataUrl`), but nothing ever served that path — so clients that follow the spec's discovery flow got a 404. In EXTERNAL mode this made authorization-server discovery effectively impossible except through the legacy shim.

**Changes** (in `src/index.ts`, mirroring the existing inline metadata shim style):

- Serve **RFC 9728 Protected Resource Metadata** at `/.well-known/oauth-protected-resource` (the exact URL advertised in 401s) and `/.well-known/oauth-protected-resource/mcp` (RFC 9728 §3.1 path insertion, for clients that derive the metadata URL from the `/mcp` endpoint themselves). `authorization_servers` points at the in-process server in INTERNAL mode and at `AUTH_SERVER_URL` in EXTERNAL mode.
- **Kept** the `/.well-known/oauth-authorization-server` shim rather than removing it as the issue suggests: clients of the 2025-03-26 spec revision discover auth by querying that path on the MCP server directly, and in EXTERNAL mode the shim correctly points them at the external AS endpoints. It's now commented as a back-compat shim; happy to remove it instead if you'd prefer strict current-spec behavior.

**Verified** by booting both modes and curling:
- EXTERNAL (`AUTH_MODE=external AUTH_SERVER_URL=http://localhost:3001`): both PRM endpoints return `authorization_servers: ["http://localhost:3001"]`, and the URL in the 401's `WWW-Authenticate: ... resource_metadata="…"` now resolves.
- INTERNAL: PRM returns the server itself as the authorization server.

`npm run build`, `npx eslint`, and the jest suite (79 tests, 6 suites) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)